### PR TITLE
Fix a crash when rotating screen

### DIFF
--- a/GreekReference/src/main/java/com/benlinskey/greekreference/views/detail/lexicon/LexiconDetailFragment.java
+++ b/GreekReference/src/main/java/com/benlinskey/greekreference/views/detail/lexicon/LexiconDetailFragment.java
@@ -16,6 +16,7 @@
 
 package com.benlinskey.greekreference.views.detail.lexicon;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -28,6 +29,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -60,12 +62,18 @@ public class LexiconDetailFragment extends AbstractDetailFragment {
 
     private LexiconEntry mLexiconEntry = null;
     private boolean mBlank = true; // True if no entry displayed.
+    private FragmentActivity mActivity = null;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
      */
     public LexiconDetailFragment() {}
+
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        mActivity = (FragmentActivity) activity;
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -128,7 +136,7 @@ public class LexiconDetailFragment extends AbstractDetailFragment {
      *     otherwise
      */
     private boolean perseusToolOptionDisabled() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mActivity);
         return prefs.getBoolean(getString(R.string.pref_perseus_tool_key), false);
     }
 


### PR DESCRIPTION
Fixes #142. It looks like getActivity() was sometimes returning null
on screen rotation because the parent activity had been destroyed and
not yet recreated. We now save a reference to the activity in
onAttach(). Unfortunately I can't reproduce this bug, so I can't verify
with certainty that this will fix it, but I think this will do the
trick.